### PR TITLE
Change instances of 'class' to 'className'

### DIFF
--- a/src/app/components/Card.js
+++ b/src/app/components/Card.js
@@ -7,7 +7,7 @@ const Card = (props) => {
             <Image id="pic" src={props.image} width="400" height="450" />
             <div id="officer-description">
                 <br />
-                <h2 class="officer-name">{props.name}</h2>
+                <h2 className="officer-name">{props.name}</h2>
                 <p id="officer-title-name">{props.title}</p>
                 <br />
             </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -16,12 +16,12 @@ const Home = () =>
   return (
     <section id="base-background">
 
-      <div class="section section-home">
+      <div className="section section-home">
 
         <div id="hometitle" className="grid">
           <div id="title">
             <h2 id="big">Hey UGA!</h2>
-            <h1 id="big">We're <div class="red-bold">DevDogs</div>,</h1>
+            <h1 id="big">We're <div className="red-bold">DevDogs</div>,</h1>
           </div>
           <Image id="mascot" src={logo} alt="DevDogs Logo" width="800" height="800" />
         </div>
@@ -34,15 +34,15 @@ const Home = () =>
             <h1>a team of</h1>
             <h1>passionate</h1>
             <h1 id="big" >Student</h1>
-            <h1 id="big" class="dark_red-bold">Developers</h1>
+            <h1 id="big" className="dark_red-bold">Developers</h1>
             <h2>at UGA.</h2>
           </div>
         </div>
         <br />
         <div id="who-we-are" className="grid">
           <div>
-            <p class="section-header"><b><b class="dark_red-bold">We</b> develop some awesome software...</b></p>
-            <p class="section-subheader">And we strive to better our community through code.</p>
+            <p className="section-header"><b><b className="dark_red-bold">We</b> develop some awesome software...</b></p>
+            <p className="section-subheader">And we strive to better our community through code.</p>
             <p>Each year, we work hard to identify needs in Athens and solve them by taking solutions from concept to completion.</p>
           </div>
           <Image id="mockup-home" src={mockup} alt="ACM OSP Bus App Mockup" width="650" height="400" />
@@ -52,8 +52,8 @@ const Home = () =>
         <HomePageCarousel roles={roles} />
 
 
-        <div class="call-to-action-home">
-          <h1 class="section-header-center">Sound interesting?</h1>
+        <div className="call-to-action-home">
+          <h1 className="section-header-center">Sound interesting?</h1>
 
 
           <div className="button-grid">


### PR DESCRIPTION
Next was complaining about invalid usages of `class` every time you request a page. This PR fixes that. Basically just a `%s/class=/className=/g`.
| Before | This PR |
| - | - |
| ![image](https://github.com/user-attachments/assets/fe63f85f-4afb-4a2d-b3a5-c2482dba3b17) | ![image](https://github.com/user-attachments/assets/db0509de-9c0f-40ce-801b-7ccb601599df) |